### PR TITLE
Refactored the results screen: more performant, optimised.

### DIFF
--- a/server/mpr/static/css/custom.css
+++ b/server/mpr/static/css/custom.css
@@ -9,7 +9,8 @@ main {}
 #resultsheader {display:none; margin-top:20px; margin-bottom:5px;}
 .js-results #resultsheader {visibility:visible;}
 #noresults {display:none; margin-top:10px;}
-.template {display:none;}
+.template,
+.template-panel-body {position:absolute; left:-9999em;}
 
 .product {}
 	.product .panel-heading {overflow:hidden;}
@@ -18,6 +19,7 @@ main {}
 	.product dl {margin-bottom:0;}
 	.product dt {float:left; clear:left;}
 	.product dd {text-align:right;}
+	.product .collapsing {-webkit-transition:none; transition:none;}
 	.product .panel-footer {overflow:hidden; background-color:#fcfcfc; color:#999; border-top:1px solid #ddd;}
 		.product .panel-footer p {margin:0;}
 			a.related {float:right; text-decoration:none; margin:0 0 0 10px;}

--- a/server/mpr/templates/index.html
+++ b/server/mpr/templates/index.html
@@ -11,41 +11,41 @@
         <div id="product_results" class="products panel-group">
             <div class="template panel panel-default">
                 <div class="panel-heading">
-                    <a class="panel-title product-name accordion-toggle" data-toggle="collapse" data-parent="#product_results"></a>
+                    <a class="panel-title product-name collapse in" data-toggle="collapse" href="#"></a>
                     <span class="product-price"></span>
                 </div>
-                <div class="panel-collapse collapse in">
-                    <div class="panel-body">
-                        <div class="product-details">
-                            <div class="col-sm-6 details">
-                                <h4>Product details</h4>
-                                <dl>
-                                    <dt>Max price (incl VAT):</dt>
-                                    <dd></dd>
-                                    <dt>Schedule:</dt>
-                                    <dd></dd>
-                                    <dt>Dosage form:</dt>
-                                    <dd></dd>
-                                    <dt>Pack quantity/ml:</dt>
-                                    <dd></dd>
-                                    <dt>Number of packs:</dt>
-                                    <dd></dd>
-                                    <dt>Generic/Innovator:</dt>
-                                    <dd></dd>
-                                </dl>
-                            </div>
-                            <div class="col-sm-6 ingredients">
-                                <h4>Ingredients</h4>
-                                <dl></dl>
-                            </div>
+            </div>
+            <div class="template-panel-body panel-collapse collapse in">
+                <div class="panel-body">
+                    <div class="product-details">
+                        <div class="col-sm-6 details">
+                            <h4>Product details</h4>
+                            <dl>
+                                <dt>Max price (incl VAT):</dt>
+                                <dd></dd>
+                                <dt>Schedule:</dt>
+                                <dd></dd>
+                                <dt>Dosage form:</dt>
+                                <dd></dd>
+                                <dt>Pack quantity/ml:</dt>
+                                <dd></dd>
+                                <dt>Number of packs:</dt>
+                                <dd></dd>
+                                <dt>Generic/Innovator:</dt>
+                                <dd></dd>
+                            </dl>
+                        </div>
+                        <div class="col-sm-6 ingredients">
+                            <h4>Ingredients</h4>
+                            <dl></dl>
                         </div>
                     </div>
-                    <div class="panel-footer">
-                        <p>
-                            <a class="related" href="#">Related Products</a>
-                            Registration number: <span class="product-reg-number"></span>
-                        </p>
-                    </div>
+                </div>
+                <div class="panel-footer">
+                    <p>
+                        <a class="related" href="#">Related Products</a>
+                        Registration number: <span class="product-reg-number"></span>
+                    </p>
                 </div>
             </div>
         </div>

--- a/server/mpr/urls.py
+++ b/server/mpr/urls.py
@@ -9,6 +9,7 @@ admin.autodiscover()
 urlpatterns = patterns("",
     url(r'^$', TemplateView.as_view(template_name="index.html"), name="home"),
     url(r"^api/related$", "mpr.views.related_products", name="api_related_products"),
+    url(r"^api/detail$", "mpr.views.product_detail", name="api_product_detail"),
     url(r"^api/search/by_product$", "mpr.views.search_by_product", name="api_search_by_product"),
     url(r"^api/search/by_ingredient$", "mpr.views.search_by_ingredient", name="api_search_by_ingredient"),
     url(r"^api/search$", "mpr.views.search", name="api_search"),

--- a/server/mpr/views.py
+++ b/server/mpr/views.py
@@ -54,3 +54,12 @@ def related_products(request):
         ), mimetype="application/json"
     )
     
+def product_detail(request):
+    product_id = request.GET.get("product", "").strip()
+    product = get_object_or_404(models.Product, id=product_id)
+
+    return HttpResponse(
+        json.dumps(
+            serialisers.serialize_product(product), indent=4
+        ), mimetype="application/json"
+    )


### PR DESCRIPTION
Product Results now use a simplified template
Added a click handler to the product detail to load additional data from another cloned template.
Added a new API call for product detail: /api/detail?product=[ID]
Switched off the collapse animations on expanded products - slow on mobile if there are hundreds of results.
